### PR TITLE
Add simple key value store to cerulean

### DIFF
--- a/cerulean.go
+++ b/cerulean.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/goshlanguage/cerulean/pkg/lightdb"
 	"github.com/goshlanguage/cerulean/services"
 	"github.com/goshlanguage/cerulean/services/subscriptions"
 	"github.com/labstack/echo/v4"
@@ -17,6 +18,7 @@ type Cerulean struct {
 	BaseSubscriptionID string
 	Echo               *echo.Echo
 	Services           []services.Service
+	Store              *lightdb.Store
 }
 
 // New sets up an instance of our mock and returns it
@@ -45,6 +47,7 @@ func New() Cerulean {
 		BaseSubscriptionID: baseSub,
 		Echo:               e,
 		Services:           svcs,
+		Store:              lightdb.NewStore(),
 	}
 	server.ListenAndServe()
 

--- a/pkg/lightdb/store.go
+++ b/pkg/lightdb/store.go
@@ -1,0 +1,34 @@
+package lightdb
+
+import "fmt"
+
+type Store struct {
+	Data map[string]string
+}
+
+// NewStore is a factory for our store
+func NewStore() *Store {
+	return &Store{
+		Data: make(map[string]string),
+	}
+}
+
+// Put adds a new key value pair to the store or updates the key if present
+func (s *Store) Put(key string, value string) error {
+	s.Data[key] = value
+	return nil
+}
+
+// Get returns the value for the key if it exists
+func (s *Store) Get(key string) (string, error) {
+	if val, ok := s.Data[key]; ok {
+		return val, nil
+	}
+	return "", fmt.Errorf("Key does not exist")
+}
+
+// Delete takes a key and removes the value stored there if it exists
+func (s *Store) Delete(key string) error {
+	delete(s.Data, key)
+	return nil
+}

--- a/pkg/lightdb/store_test.go
+++ b/pkg/lightdb/store_test.go
@@ -1,0 +1,40 @@
+package lightdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStore(t *testing.T) {
+	expected := "{'a': 'b'}"
+
+	s := NewStore()
+	s.Put("/subscriptions/", "{'a': 'b'}")
+
+	value, err := s.Get("/subscriptions/")
+	assert.NoError(t, err, "Didn't expect error when getting previously stored key, got: %s", err)
+	assert.Equal(
+		t,
+		expected,
+		value,
+		"Got incorrect value from key. Expected %s, got: %s",
+		expected,
+		value,
+	)
+
+	err = s.Delete("/subscriptions/")
+	assert.NoError(
+		t,
+		err,
+		"Expected no errors from Delete. Error: %s",
+		err,
+	)
+
+	_, err = s.Get("/subscriptions/")
+	assert.EqualError(
+		t,
+		err,
+		"Key does not exist",
+	)
+}


### PR DESCRIPTION
I think that adding a key value store as an intermediary between cerulean and the services will help relieve some of the design limitations we're seeing in regards to storing objects. 

A normal API would store data in some sort of database, which this seeks to replicate. 

Choosing a key value store seemed to make sense. My thought is that we will serialize and deserialize json from what's stored in the key value store (map).  