### PR TITLE
Testing out how non-stuttering/standardized function names feels

### DIFF
--- a/cerulean.go
+++ b/cerulean.go
@@ -32,7 +32,7 @@ func New() Cerulean {
 	s := lightdb.NewStore()
 	e.HideBanner = true // Make log output less noisy by removing ASCII artwork
 
-	subscriptionsSVC := subscriptions.NewSubscriptionService(s)
+	subscriptionsSVC := subscriptions.NewService(s)
 	baseSub := subscriptionsSVC.GetBaseSubscriptionID()
 
 	svcs := []services.Service{

--- a/internal/services/subscriptions/handlers.go
+++ b/internal/services/subscriptions/handlers.go
@@ -7,8 +7,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// GetSubscriptionsHandler is the GET method handler for /subscriptions
-func (svc *SubscriptionService) GetSubscriptionsHandler() echo.HandlerFunc {
+// GetHandler is the GET method handler for /subscriptions
+func (svc *Service) GetHandler() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		subsString := svc.Store.Get("subscriptions")
 
@@ -20,7 +20,7 @@ func (svc *SubscriptionService) GetSubscriptionsHandler() echo.HandlerFunc {
 				panic(err)
 			}
 
-			response := SubscriptionResponse{
+			response := Response{
 				Value: subs,
 			}
 
@@ -30,13 +30,13 @@ func (svc *SubscriptionService) GetSubscriptionsHandler() echo.HandlerFunc {
 	}
 }
 
-// PostSubscriptionsHandler is the POST method handler for /subscriptions
+// PostHandler is the POST method handler for /subscriptions
 // POST https://management.azure.com/providers/Microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoiceSections/{invoiceSectionName}/providers/Microsoft.Subscription/createSubscription?api-version=2018-11-01-preview
 // 202 Accepted
 // Response: {
 // 	"subscriptionLink": "/subscriptions/d0d6ee57-6530-4fca-93a6-b755a070be35"
 // }
-func PostSubscriptionsHandler(pattern string, subs *[]Subscription) echo.HandlerFunc {
+func PostHandler(pattern string, subs *[]Subscription) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		return nil
 	}

--- a/internal/services/subscriptions/handlers_test.go
+++ b/internal/services/subscriptions/handlers_test.go
@@ -10,18 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestGetSubscriptionsHandler sets up a server and tests the endpoint directly
-func TestGetSubscriptionsHandler(t *testing.T) {
+// TestGetHandler sets up a server and tests the endpoint directly
+func TestGetHandler(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
 
 	s := lightdb.NewStore()
-	subscriptionService := SubscriptionService{
+	subscriptionService := Service{
 		Store: s,
 	}
-	getHandler := subscriptionService.GetSubscriptionsHandler()
+	getHandler := subscriptionService.GetHandler()
 
 	// Assert that there were no errors and our subscriptions service returned a blank response because no subscriptions exist
 	if assert.NoError(t, getHandler(ctx)) {

--- a/internal/services/subscriptions/models.go
+++ b/internal/services/subscriptions/models.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var subscriptionsJSON = `
+var sampleJSON = `
 {
   "value": [
     {
@@ -32,25 +32,13 @@ var subscriptionsJSON = `
 }
 `
 
-// SubscriptionResponse models the subscription response from the API
-type SubscriptionResponse struct {
+// Response models the subscription response from the API
+type Response struct {
 	Value []Subscription `json:"value"`
 	Count struct {
 		Type  string `json:"type"`
 		Value int    `json:"value"`
 	} `json:"count"`
-}
-
-// NewSubscriptionResponseStub takes a string ID and returns a basic SubscriptionResponse object
-// TODO: Support passing multiple subscription IDs
-func NewSubscriptionResponseStub(subscriptionID string) SubscriptionResponse {
-	var response SubscriptionResponse
-	json.Unmarshal([]byte(subscriptionsJSON), &response)
-
-	response.Value[0].ID = fmt.Sprintf("/subscriptions/%s", subscriptionID)
-	response.Value[0].SubscriptionID = fmt.Sprintf("%s", subscriptionID)
-
-	return response
 }
 
 // Subscription is the object we store in our Inventory grab bag to model a subscription
@@ -69,6 +57,18 @@ type Subscription struct {
 	} `json:"subscriptionPolicies"`
 }
 
+// NewResponseStub takes a string ID and returns a basic SubscriptionResponse object
+// TODO: Support passing multiple subscription IDs
+func NewResponseStub(subscriptionID string) Response {
+	var response Response
+	json.Unmarshal([]byte(sampleJSON), &response)
+
+	response.Value[0].ID = fmt.Sprintf("/subscriptions/%s", subscriptionID)
+	response.Value[0].SubscriptionID = fmt.Sprintf("%s", subscriptionID)
+
+	return response
+}
+
 // NewSubscription takes a string ID and returns a basic Subscription object
 // It does this by indirectly using the NewSubscriptionResponse factory for the sake of loading in a JSON stub,
 //   and replacing the SubscriptionID in said stub to constructr our Subscription.
@@ -80,5 +80,5 @@ func NewSubscription() Subscription {
 		panic(err)
 	}
 
-	return NewSubscriptionResponseStub(id.String()).Value[0]
+	return NewResponseStub(id.String()).Value[0]
 }

--- a/internal/services/subscriptions/service.go
+++ b/internal/services/subscriptions/service.go
@@ -11,15 +11,15 @@ import (
 
 const serviceKey = "subscriptions"
 
-// SubscriptionService satisfies the Service interface, and is used to start and maintain the Subscription Service
-type SubscriptionService struct {
+// Service satisfies the Service interface, and is used to start and maintain the Subscription Service
+type Service struct {
 	Store *lightdb.Store
 }
 
-// NewSubscriptionService is a factory for the SubscriptionService, which satisfies the services.Service interface and provides a default sub
+// NewService is a factory for the SubscriptionService, which satisfies the services.Service interface and provides a default sub
 // TODO Error handling
-func NewSubscriptionService(s *lightdb.Store) *SubscriptionService {
-	service := &SubscriptionService{
+func NewService(s *lightdb.Store) *Service {
+	service := &Service{
 		Store: s,
 	}
 	initSub := NewSubscription()
@@ -29,17 +29,17 @@ func NewSubscriptionService(s *lightdb.Store) *SubscriptionService {
 }
 
 // GetHandlers returns a map of all HTTP Echo handlers that the service needs in order to operate
-func (svc *SubscriptionService) GetHandlers() map[string]services.Handler {
+func (svc *Service) GetHandlers() map[string]services.Handler {
 	svcMap := make(map[string]services.Handler)
 	svcMap["/subscriptions"] = services.Handler{
 		Verb: http.MethodGet,
-		Func: svc.GetSubscriptionsHandler(),
+		Func: svc.GetHandler(),
 	}
 	return svcMap
 }
 
 // GetBaseSubscriptionID is a SubscriptionService specific helper that returns the initial subscriptionID
-func (svc *SubscriptionService) GetBaseSubscriptionID() string {
+func (svc *Service) GetBaseSubscriptionID() string {
 	subsString := svc.Store.Get(serviceKey)
 
 	var subs []Subscription
@@ -52,7 +52,7 @@ func (svc *SubscriptionService) GetBaseSubscriptionID() string {
 }
 
 // GetSubscriptions returns the Stores state
-func (svc *SubscriptionService) GetSubscriptions() ([]Subscription, error) {
+func (svc *Service) GetSubscriptions() ([]Subscription, error) {
 	var subs []Subscription
 	subsString := svc.Store.Get(serviceKey)
 
@@ -65,7 +65,7 @@ func (svc *SubscriptionService) GetSubscriptions() ([]Subscription, error) {
 }
 
 // AddSubscription takes a subscription and adds it to the store
-func (svc *SubscriptionService) AddSubscription(s Subscription) error {
+func (svc *Service) AddSubscription(s Subscription) error {
 	subsString := svc.Store.Get(serviceKey)
 
 	// if there are existing subs, be sure to deserialize the response and append

--- a/internal/services/subscriptions/service_test.go
+++ b/internal/services/subscriptions/service_test.go
@@ -10,7 +10,7 @@ import (
 // TestAddAndGetSubscription creates a store and tests out the AddSubscription(s Subscription) helper to ensure it functions as expected
 func TestAddSubscription(t *testing.T) {
 	s := lightdb.NewStore()
-	svc := NewSubscriptionService(s)
+	svc := NewService(s)
 
 	newSub := NewSubscription()
 	err := svc.AddSubscription(newSub)
@@ -23,7 +23,7 @@ func TestAddSubscription(t *testing.T) {
 
 func TestGetSubscriptions(t *testing.T) {
 	s := lightdb.NewStore()
-	svc := NewSubscriptionService(s)
+	svc := NewService(s)
 
 	subs, err := svc.GetSubscriptions()
 	assert.NoError(t, err, "Tried to get subscriptions from service helper but received error: %s", err)


### PR DESCRIPTION
When starting work on the `resourcegroups` package, my linter told me that stuff like `resourcegroups.ResourceGroupsResponse` stutters and should be avoided. Realized that we technically had a lot of stuttering in the subscriptions package already. This PR fixes that.

I'm up for discussion on moving in this direction. I kinda like it because we'll end up with a more standard "API" with our function calls internally (e.g. `subscriptions.GetHandler` and `resourcegroups.GetHandler` instead of the more verbose `subscriptions.GetSubscriptionsHandler` and `resourcegroups.GetResourceGroupsHandler`).